### PR TITLE
Bump version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         node: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
@@ -25,7 +25,7 @@ jobs:
       matrix:
         node: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
@@ -38,7 +38,7 @@ jobs:
       matrix:
         node: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
@@ -51,7 +51,7 @@ jobs:
       matrix:
         node: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
@@ -63,7 +63,7 @@ jobs:
       matrix:
         node: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
@@ -74,7 +74,7 @@ jobs:
     needs: [build, unit-test, smoke-test, lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: 14

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         node: [12, 14, 16]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: node --version
@@ -26,7 +26,7 @@ jobs:
         node: [12, 14, 16]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: node --version
@@ -39,7 +39,7 @@ jobs:
         node: [12, 14, 16]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci
@@ -52,7 +52,7 @@ jobs:
         node: [12, 14, 16]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci
@@ -64,7 +64,7 @@ jobs:
         node: [12, 14, 16]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 title: Changelog
 ---
 
+* Remove support for Node.js version 12. ([#1560](https://github.com/nextstrain/auspice/pull/1560))
+* Add support for Node.js version 18 and NPM version 9. ([#1560](https://github.com/nextstrain/auspice/pull/1560))
+
 ## version 2.44.0 - 2023/03/02
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 title: Changelog
 ---
 
+## version 2.45.0 - 2023/03/08
+
+
 * Remove support for Node.js version 12. ([#1560](https://github.com/nextstrain/auspice/pull/1560))
 * Add support for Node.js version 18 and NPM version 9. ([#1560](https://github.com/nextstrain/auspice/pull/1560))
 

--- a/docs/advanced-functionality/view-settings.md
+++ b/docs/advanced-functionality/view-settings.md
@@ -72,7 +72,7 @@ All URL queries modify the view away from the default settings -- if you change 
 | `d`        | List of panels to display, `,` separated | `d=tree,map` |
 | `p`        | Panel layout (buggy!) | `p=full`, `p=grid` |
 | `gmin`     | Entropy panel zoom (minimum) bound | `gmin=1000` |
-| `gmin`     | Entropy panel zoom (maximum) bound | `gmax=2000` |
+| `gmax`     | Entropy panel zoom (maximum) bound | `gmax=2000` |
 | `animate`  | Animation settings | |
 | `n`        | Narrative page number | `n=1` goes to the first page |
 | `s`        | Selected strain | `s=1_0199_PF` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auspice",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "description": "Web app for visualizing pathogen evolution",
   "author": "James Hadfield, Trevor Bedford and Richard Neher",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "github:nextstrain/auspice",
   "homepage": "https://www.npmjs.com/package/auspice",
   "engines": {
-    "node": "^12 || ^14 || ^16",
+    "node": "^12 || ^14 || ^16 || ^18",
     "npm": "^7 || ^8"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "github:nextstrain/auspice",
   "homepage": "https://www.npmjs.com/package/auspice",
   "engines": {
-    "node": "^12 || ^14 || ^16 || ^18",
+    "node": "^14 || ^16 || ^18",
     "npm": "^7 || ^8"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://www.npmjs.com/package/auspice",
   "engines": {
     "node": "^14 || ^16 || ^18",
-    "npm": "^7 || ^8"
+    "npm": "^7 || ^8 || ^9"
   },
   "bin": {
     "auspice": "./auspice.js"

--- a/src/version.js
+++ b/src/version.js
@@ -1,4 +1,4 @@
-const version = "2.44.0";
+const version = "2.45.0";
 
 module.exports = {
   version


### PR DESCRIPTION
This PR is to update with the changes made to the head repo.  The pertinent update is the added support for node.js v18 and npm v9, which should bring it in line with what's being used for the other parts of ViewBovis.  Updates to `APHA_install.md` will be made to reflect this in a future PR