### PR TITLE
Change default port

### DIFF
--- a/APHA_install.md
+++ b/APHA_install.md
@@ -4,9 +4,9 @@ Install Node Version Manager (nvm)
 
 `wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash`
 
-Install node.js v16 (the latest supported by Auspice)
+Install node.js v18 (the latest supported by Auspice)
 
-`nvm install 16`
+`nvm install 18`
 
 Clone Auspice repo
 

--- a/cli/develop.js
+++ b/cli/develop.js
@@ -33,7 +33,7 @@ const addParser = (parser) => {
 const run = (args) => {
   /* Basic server set up */
   const app = express();
-  app.set('port', process.env.PORT || 4000);
+  app.set('port', process.env.PORT || 4001);
   app.set('host', process.env.HOST || "localhost");
 
   const baseDir = path.resolve(__dirname, "..");

--- a/cli/view.js
+++ b/cli/view.js
@@ -100,7 +100,7 @@ const getAuspiceBuild = () => {
 const run = (args) => {
   /* Basic server set up */
   const app = express();
-  app.set('port', process.env.PORT || 4000);
+  app.set('port', process.env.PORT || 4001);
   app.set('host', process.env.HOST || "localhost");
   app.use(compression());
   app.use(nakedRedirect({reverse: true})); /* redirect www.name.org to name.org */


### PR DESCRIPTION
This is just a small change to switch the default port used by Auspice as the original clashes with the standard SCE setup.  Also update the install instructions for node.js v 18