### PR TITLE
Change default panel view to GRID

### DIFF
--- a/src/actions/panelDisplay.js
+++ b/src/actions/panelDisplay.js
@@ -18,6 +18,6 @@ export const togglePanelDisplay = (panelName) => (dispatch, getState) => {
     panelsToDisplay.splice(idx, 1);
   }
   const canTogglePanelLayout = hasMultipleGridPanels(panelsToDisplay);
-  const panelLayout = canTogglePanelLayout ? controls.panelLayout : "full";
+  const panelLayout = canTogglePanelLayout ? controls.panelLayout : "grid";
   dispatch({type: TOGGLE_PANEL_DISPLAY, panelsToDisplay, panelLayout, canTogglePanelLayout});
 };


### PR DESCRIPTION
Small change to the source code located `./src/actions/panelDisplay.js`. Changed `full` to `grid`, which by default present the tree and map side-by-side. 

![image](https://user-images.githubusercontent.com/20986547/225614977-11327d02-70c8-4cd3-a99a-c463e869955e.png)
