### PR TITLE
Revert "Change default panel view to GRID"

### DIFF
--- a/src/actions/panelDisplay.js
+++ b/src/actions/panelDisplay.js
@@ -18,6 +18,6 @@ export const togglePanelDisplay = (panelName) => (dispatch, getState) => {
     panelsToDisplay.splice(idx, 1);
   }
   const canTogglePanelLayout = hasMultipleGridPanels(panelsToDisplay);
-  const panelLayout = canTogglePanelLayout ? controls.panelLayout : "grid";
+  const panelLayout = canTogglePanelLayout ? controls.panelLayout : "full";
   dispatch({type: TOGGLE_PANEL_DISPLAY, panelsToDisplay, panelLayout, canTogglePanelLayout});
 };


### PR DESCRIPTION
Reverts APHA-CSU/auspice#5

I have found a more convenient way to programmatically change the panel view layout from within ViewBovis JavaScript, which avoids the need to edit the source code of auspice. Therefore, I am reverting this change.