### PR TITLE
Display refinements

### DIFF
--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -192,7 +192,7 @@ const getTraitsToDisplay = (node) => {
   // TODO -- this should be centralised somewhere
   if (!node.node_attrs) return [];
   const ignore = ["author", "div", "num_date", "gisaid_epi_isl", "genbank_accession", "accession", "url"];
-  return Object.keys(node.node_attrs).filter((k) => !ignore.includes(k));
+  return Object.keys(node.node_attrs).sort().filter((k) => !ignore.includes(k));
 };
 
 const Trait = ({node, trait, colorings, isTerminal}) => {

--- a/src/globalStyles.js
+++ b/src/globalStyles.js
@@ -244,7 +244,7 @@ export const infoPanelStyles = {
   },
   comment: {
     fontStyle: "italic",
-    fontWeight: 200,
+    fontWeight: 300,
     fontSize: 14,
     marginTop: "10px"
   },


### PR DESCRIPTION
A couple of minor changes to the display in the popup when nodes are clicked

- Use `sort()` to ensure that the information is shown in the same order - the elements could appear in a random order without this
- The message to go back to the tree has been made more visible

See the example 

![image](https://user-images.githubusercontent.com/9665142/228957313-53caebc3-e3f4-4cf3-869c-2e1cb21b22e6.png)
 