### PR TITLE
More refinements

### DIFF
--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -41,9 +41,9 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
         Downloaded data represents the currently displayed view.
         By zooming the tree, changing the branch-length metric, applying filters etc, the downloaded data will change accordingly.
         <p/>
-        NOTE: We do not support downloads of multiple subtrees, which are usually created with the date range filter or genotype filters.
+        {/*NOTE: We do not support downloads of multiple subtrees, which are usually created with the date range filter or genotype filters.
         Downloading multiple subtrees will result in an empty Newick tree!
-        <p/>
+  <p/>*/}
         {partialData ? `Currently ${selectedTipsCount}/${totalTipCount} tips are displayed and will be downloaded.` : `Currently the entire dataset (${totalTipCount} tips) will be downloaded.`}
       </div>
       <Button
@@ -82,14 +82,14 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
           onClick={() => helpers.authorTSV(dispatch, filePrefix, tree)}
         />
       )}
-      {entropy.loaded && (
+      {/*{entropy.loaded && (
         <Button
           name="Genetic diversity data (TSV)"
           description={`The data behind the diversity panel showing ${entropy.showCounts?`a count of changes across the tree`:`normalised shannon entropy`} per ${mutType==="nuc"?"nucleotide":"codon"}.`}
           icon={<MetaIcon width={iconWidth} selected />}
           onClick={() => helpers.entropyTSV(dispatch, filePrefix, entropy, mutType)}
         />
-      )}
+      )}*/}
       <Button
         name="Screenshot (SVG)"
         description="Screenshot of the current nextstrain display in SVG format; CC-BY licensed."

--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -5,7 +5,7 @@ import { withTranslation } from 'react-i18next';
 import { TRIGGER_DOWNLOAD_MODAL, DISMISS_DOWNLOAD_MODAL } from "../../actions/types";
 import { infoPanelStyles } from "../../globalStyles";
 import { stopProp } from "../tree/infoPanels/click";
-import { getAcknowledgments} from "../framework/footer";
+//import { getAcknowledgments} from "../framework/footer";
 import { datasetSummary } from "../info/datasetSummary";
 import { DownloadButtons } from "./downloadButtons";
 
@@ -171,12 +171,12 @@ class DownloadModal extends React.Component {
               t: this.props.t
             })}
           </div>
-          <div style={infoPanelStyles.break}/>
+          {/*<div style={infoPanelStyles.break}/>
           {" " + t("A full list of sequence authors is available via the TSV files below")}
           <div style={infoPanelStyles.break}/>
-          {getAcknowledgments({}, {preamble: {fontWeight: 300}, acknowledgments: {fontWeight: 300}})}
+          {getAcknowledgments({}, {preamble: {fontWeight: 300}, acknowledgments: {fontWeight: 300}})}*/}
 
-          <div style={infoPanelStyles.modalSubheading}>
+          {/*<div style={infoPanelStyles.modalSubheading}>
             {t("Data usage policy")}
           </div>
           {t("Data usage part 1") + " " + t("Data usage part 2")}
@@ -184,7 +184,7 @@ class DownloadModal extends React.Component {
           <div style={infoPanelStyles.modalSubheading}>
             {t("Please cite the authors who contributed genomic data (where relevant), as well as")+":"}
           </div>
-          {this.formatPublications(relevantPublications)}
+        {this.formatPublications(relevantPublications)}*/}
 
 
           <div style={infoPanelStyles.modalSubheading}>

--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -154,30 +154,30 @@ const FooterStyles = styled.div`
 
 `;
 
-export const getAcknowledgments = (metadata, dispatch) => {
+//export const getAcknowledgments = (metadata, dispatch) => {
   /**
    * If the metadata contains a description key, then it will take precedence the hard-coded
    * acknowledgements. Expects the text in the description to be in Markdown format.
    * Jover. December 2019.
   */
-  if (metadata.description) {
-    return (
-      <Suspense fallback={<div />}>
-        <MarkdownDisplay className="acknowledgments" mdstring={metadata.description} />
-      </Suspense>
-    );
-  }
+//  if (metadata.description) {
+//    return (
+//      <Suspense fallback={<div />}>
+//        <MarkdownDisplay className="acknowledgments" mdstring={metadata.description} />
+//      </Suspense>
+//   );
+//  }
+//
+  //const preambleContent = "This work is made possible by the open sharing of genetic data by research groups from all over the world. We gratefully acknowledge their contributions.";
+  //const genericPreamble = (<div>{preambleContent}</div>);
+//
+  //if (window.location.hostname === 'nextstrain.org') {
+  //  return hardCodedFooters(dispatch, genericPreamble);
+  //}
 
-  const preambleContent = "This work is made possible by the open sharing of genetic data by research groups from all over the world. We gratefully acknowledge their contributions.";
-  const genericPreamble = (<div>{preambleContent}</div>);
+  //return (<div>{genericPreamble}</div>);
 
-  if (window.location.hostname === 'nextstrain.org') {
-    return hardCodedFooters(dispatch, genericPreamble);
-  }
-
-  return (<div>{genericPreamble}</div>);
-
-};
+//};
 
 const dispatchFilter = (dispatch, activeFilters, key, value) => {
   const activeValuesOfFilter = activeFilters[key].map((f) => f.value);
@@ -290,8 +290,8 @@ class Footer extends React.Component {
     return (
       <FooterStyles>
         <div style={{width: width}}>
-          <div className='line'/>
-          {getAcknowledgments(this.props.metadata, this.props.dispatch)}
+{/*          <div className='line'/>
+          {getAcknowledgments(this.props.metadata, this.props.dispatch)}*/}
           <div className='line'/>
           {Object.keys(this.props.activeFilters)
             .filter((name) => this.props.filtersInFooter.includes(name))

--- a/src/components/info/datasetSummary.js
+++ b/src/components/info/datasetSummary.js
@@ -55,7 +55,7 @@ export const datasetSummary = ({nodes, visibility, mainTreeNumTips, branchLength
   let summary = ""; /* text returned from this function */
 
   /* Number of genomes & their date range */
-  if (branchLengthsToDisplay !== "divOnly" && nSelectedSamples > 0) {
+  /*if (branchLengthsToDisplay !== "divOnly" && nSelectedSamples > 0) {
     summary += t(
       "Showing {{x}} of {{y}} genomes sampled between {{from}} and {{to}}",
       {
@@ -65,9 +65,10 @@ export const datasetSummary = ({nodes, visibility, mainTreeNumTips, branchLength
         to: styliseDateRange(sampledDateRange[1])
       }
     );
-  } else {
+  } else */
+  {
     summary += t(
-      "Showing {{x}} of {{y}} genomes",
+      "Showing {{x}} of {{y}} genomes available for this clade",
       {x: nSelectedSamples, y: mainTreeNumTips}
     );
   }

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -411,8 +411,8 @@ const HoverInfoPanel = ({
         <>
           <StrainName name={node.name}/>
           <VaccineInfo node={node} t={t}/>
-          <TipMutations node={node} t={t}/>
-          <BranchLength node={node} t={t}/>
+          {/*<TipMutations node={node} t={t}/>
+          <BranchLength node={node} t={t}/>*/}
           <ColorBy node={node} colorBy={colorBy} colorByConfidence={colorByConfidence} colorScale={colorScale} colorings={colorings}/>
           <AttributionInfo node={node}/>
           <Comment>{t("Click on tip to display more info")}</Comment>
@@ -420,7 +420,7 @@ const HoverInfoPanel = ({
       ) : (
         <>
           <BranchDescendents node={node} t={t}/>
-          <BranchMutations node={node} geneSortFn={geneSortFn} observedMutations={observedMutations} t={t}/>
+          {/*<BranchMutations node={node} geneSortFn={geneSortFn} observedMutations={observedMutations} t={t}/>*/}
           <BranchLength node={node} t={t}/>
           <ColorBy node={node} colorBy={colorBy} colorByConfidence={colorByConfidence} colorScale={colorScale} colorings={colorings}/>
           <Comment>

--- a/src/globalStyles.js
+++ b/src/globalStyles.js
@@ -250,7 +250,7 @@ export const infoPanelStyles = {
   },
   topRightMessage: {
     fontStyle: "italic",
-    fontWeight: 200,
+    fontWeight: 300,
     fontSize: 14,
     textAlign: "right",
     marginTop: "-20px"


### PR DESCRIPTION
This includes a couple of small changes to various popups and interfaces to make them more relevant to APHA's use case.  These have just been commented out at the moment, so that they can be added back in or adapted if required.

- Removed unneeded wording and options from download interface
- Removed unneeded items from hover box

The aim is to clean up the overall feel of Nextstrain