### PR TITLE
Remove padding between back button and Dataset component

### DIFF
--- a/src/components/controls/styles.js
+++ b/src/components/controls/styles.js
@@ -18,7 +18,7 @@ export const ControlsContainer = styled.div`
   flex-shrink: 1;
   flex-basis: auto;
   align-self: auto;
-  padding: 50px 20px 20px 20px;
+  padding: 0 20px 20px 20px;
 `;
 
 export const HeaderContainer = styled.div`


### PR DESCRIPTION
This PR removes padding between the back button and the Dataset component.

Before:
![remove-padding-screenshot](https://user-images.githubusercontent.com/20986547/231716466-02e20196-926c-4507-b9b4-a181af7809a5.PNG)

After:
![remove-padding-screenshot-final](https://user-images.githubusercontent.com/20986547/231716488-c8e4a2c9-3da7-4eee-abac-f0a11dad186d.PNG)
