### PR TITLE
reinstate sidebar toggle

### DIFF
--- a/src/components/controls/styles.js
+++ b/src/components/controls/styles.js
@@ -18,7 +18,7 @@ export const ControlsContainer = styled.div`
   flex-shrink: 1;
   flex-basis: auto;
   align-self: auto;
-  padding: 50px 20px 20px 20px;
+  padding: 0px 20px 20px 20px;
 `;
 
 export const HeaderContainer = styled.div`

--- a/src/components/main/sidebar.js
+++ b/src/components/main/sidebar.js
@@ -18,7 +18,6 @@ export const Sidebar = (
         />
         <Controls
             mobileDisplay={mobileDisplay}
-            toggleHandler={navBarHandler}
             mapOn={panelsToDisplay.includes("map")}
             frequenciesOn={panelsToDisplay.includes("frequencies")}
             measurementsOn={panelsToDisplay.includes("measurements")}

--- a/src/components/main/sidebar.js
+++ b/src/components/main/sidebar.js
@@ -2,19 +2,28 @@ import React from "react";
 import {ThemeProvider} from 'styled-components';
 import Controls from "../controls/controls";
 import { SidebarContainer, sidebarTheme } from "./styles";
+import SidebarChevron from "../framework/sidebar-chevron";
+import NavBar from "../navBar";
 
 export const Sidebar = (
-  {sidebarOpen, width, height, panelsToDisplay, mobileDisplay}
+  {sidebarOpen, width, height, panelsToDisplay, toggleHandler, mobileDisplay, navBarHandler}
 ) => {
   return (
     <ThemeProvider theme={sidebarTheme}>
       <SidebarContainer left={sidebarOpen ? 0 : -1 * width} width={width} height={height}>
-          <Controls
+        <NavBar
+          sidebar
+          mobileDisplay={mobileDisplay}
+          toggleHandler={navBarHandler}
+          width={width}
+        />
+        <Controls
             mobileDisplay={mobileDisplay}
+            toggleHandler={navBarHandler}
             mapOn={panelsToDisplay.includes("map")}
             frequenciesOn={panelsToDisplay.includes("frequencies")}
             measurementsOn={panelsToDisplay.includes("measurements")}
-          />
+        />
       </SidebarContainer>
     </ThemeProvider>
   );

--- a/src/components/main/sidebar.js
+++ b/src/components/main/sidebar.js
@@ -2,7 +2,6 @@ import React from "react";
 import {ThemeProvider} from 'styled-components';
 import Controls from "../controls/controls";
 import { SidebarContainer, sidebarTheme } from "./styles";
-import SidebarChevron from "../framework/sidebar-chevron";
 import NavBar from "../navBar";
 
 export const Sidebar = (

--- a/src/components/navBar/index.js
+++ b/src/components/navBar/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-multi-spaces */
 import React from "react";
 import styled from 'styled-components';
-import { normalNavBarHeight, narrativeNavBarHeight } from "../../util/globals";
+import { normalNavBarHeight } from "../../util/globals";
 import SidebarChevron from "../framework/sidebar-chevron";
 import { AuspiceNavBar } from "./content";
 import { hasExtension, getExtension } from "../../util/extensions";

--- a/src/components/navBar/index.js
+++ b/src/components/navBar/index.js
@@ -13,7 +13,7 @@ const NavBarContainer = styled.div`
   margin-right: auto;
   margin-bottom: auto;
   margin-left: auto;
-  height: ${(props) => props.narrative ? narrativeNavBarHeight : normalNavBarHeight}px;
+  height: $0px;
   justify-content: space-between;
   align-items: center;
   overflow: hidden;
@@ -30,11 +30,6 @@ const NavBar = ({sidebar, toggleHandler, narrativeTitle, width}) => {
   const showSidebarToggle = sidebar && !narrativeTitle;
   return (
     <NavBarContainer>
-      <Content
-        narrativeTitle={narrativeTitle}
-        sidebar={sidebar}
-        width={width}
-      />
       <SidebarChevron navHeight={normalNavBarHeight} navWidth={width} display={showSidebarToggle} onClick={toggleHandler}/>
     </NavBarContainer>
   );

--- a/src/components/navBar/index.js
+++ b/src/components/navBar/index.js
@@ -13,7 +13,7 @@ const NavBarContainer = styled.div`
   margin-right: auto;
   margin-bottom: auto;
   margin-left: auto;
-  height: $0px;
+  height: 0;
   justify-content: space-between;
   align-items: center;
   overflow: hidden;


### PR DESCRIPTION
This PR just reinstates the sidebar toggle which was lost when removing the navbar and link to the splash page.  Turns out the toggle was part of the navbar component rather than the sidebar.  The height of the navbar container was then reduced to zero to remove the unwanted padding.