### PR TITLE
Defined trait order

### DIFF
--- a/Customization/custom.json
+++ b/Customization/custom.json
@@ -11,7 +11,7 @@
   "navbarComponent": "navbar.js",
   "splashComponent": "splash.js",
   "sidebarComponent": "sidebar.js",
-  "browserTitle": "APHA ViewBovis",
+  "browserTitle": "APHA Nextstrain",
   "mapTiles": {
     "api": "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
     "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",

--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -188,11 +188,16 @@ const SampleDate = ({isTerminal, node, t}) => {
   return item(t(isTerminal ? "Collection date" : "Inferred date"), numericToCalendar(date));
 };
 
+var traitOrder = {"CPH":4, "CPH_Type":5, "County":6, "Host":3, "Identifier":1,
+                  "MoveCount":10, "OutsideHomeRange":8, "PreviousMovement":9,
+                  "RiskArea":7, "Submission":2}
+
 const getTraitsToDisplay = (node) => {
   // TODO -- this should be centralised somewhere
   if (!node.node_attrs) return [];
   const ignore = ["author", "div", "num_date", "gisaid_epi_isl", "genbank_accession", "accession", "url"];
-  return Object.keys(node.node_attrs).sort().filter((k) => !ignore.includes(k));
+  return Object.keys(node.node_attrs).sort(function(a,b) { return traitOrder[a] - traitOrder[b]; })
+              .filter((k) => !ignore.includes(k));
 };
 
 const Trait = ({node, trait, colorings, isTerminal}) => {


### PR DESCRIPTION
This PR assigns a specific order to the trait information displayed when clicking on samples on the tree.  This is an improvement over the alphabetical sorting previously implemented as it allows a logical grouping of the traits - for example, the geographical information (CPH, County, RiskArea, etc) is now together and movement related information is at the bottom of the list

 
![image](https://user-images.githubusercontent.com/9665142/231828474-e65f9f69-3f2e-409b-a0c7-e4d36c3b3dd8.png)

I have also tagged the request to change the title onto this PR