### PR TITLE
Label options

### DIFF
--- a/src/components/controls/choose-tip-label.js
+++ b/src/components/controls/choose-tip-label.js
@@ -56,6 +56,8 @@ export function collectAvailableTipLabelOptions(colorings) {
      */
     {value: 'none', label: "none"},
     {value: strainSymbol, label: "Sample Name"},
+    {value: 'Submission', label: "Submisssion (e.g. AF ref)"},
+    {value: 'Identifier', label: "Identifier (e.g. Ear Tag)"},
     ...Object.entries(colorings)
       .filter((keyValue) => keyValue[0] !== 'gt' && keyValue[0] !== 'none')
       .map(([key, value]) => {


### PR DESCRIPTION
This change is linked to [btb-forestry#31](https://github.com/APHA-CSU/btb-forestry/pull/31) as auspice uses the same list for color-by and tip label drop-downs.  This adds the Submission and Identifier options back in as tip labels, and also provides some additional information about the option itself 