### PR TITLE
Adjust toggle to allow space for larger ViewBovis back button

### DIFF
--- a/src/components/controls/styles.js
+++ b/src/components/controls/styles.js
@@ -18,7 +18,7 @@ export const ControlsContainer = styled.div`
   flex-shrink: 1;
   flex-basis: auto;
   align-self: auto;
-  padding: 40px 20px 20px 20px;
+  padding: 25px 20px 20px 20px;
 `;
 
 export const HeaderContainer = styled.div`

--- a/src/components/controls/styles.js
+++ b/src/components/controls/styles.js
@@ -18,7 +18,7 @@ export const ControlsContainer = styled.div`
   flex-shrink: 1;
   flex-basis: auto;
   align-self: auto;
-  padding: 0px 20px 20px 20px;
+  padding: 40px 20px 20px 20px;
 `;
 
 export const HeaderContainer = styled.div`

--- a/src/components/framework/sidebar-toggle.js
+++ b/src/components/framework/sidebar-toggle.js
@@ -16,7 +16,7 @@ const SidebarToggle = ({sidebarOpen, mobileDisplay, handler}) => {
     width: mobileDisplay ? 60 : 14,
     height: mobileDisplay ? 60 : 44,
     position: "absolute",
-    top: mobileDisplay ? 15 : 4,
+    top: mobileDisplay ? 15 : 40,
     left: mobileDisplay ? "auto" : 0,
     right: mobileDisplay ? 20 : "auto",
     zIndex: 9000,

--- a/src/components/framework/sidebar-toggle.js
+++ b/src/components/framework/sidebar-toggle.js
@@ -16,7 +16,7 @@ const SidebarToggle = ({sidebarOpen, mobileDisplay, handler}) => {
     width: mobileDisplay ? 60 : 14,
     height: mobileDisplay ? 60 : 44,
     position: "absolute",
-    top: mobileDisplay ? 15 : 40,
+    top: mobileDisplay ? 15 : 35,
     left: mobileDisplay ? "auto" : 0,
     right: mobileDisplay ? 20 : "auto",
     zIndex: 9000,

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -81,7 +81,7 @@ function computeStyles(width, browserWidth) {
     title: {
       fontFamily: titleFont,
       fontSize: fontSize,
-      marginLeft: 150,
+      marginLeft: 100,
       marginTop: 0,
       marginBottom: 5,
       fontWeight: 500,
@@ -92,7 +92,7 @@ function computeStyles(width, browserWidth) {
     n: {
       fontFamily: headerFont,
       fontSize: 14,
-      marginLeft: 152,
+      marginLeft: 102,
       marginTop: 5,
       marginBottom: 5,
       fontWeight: 500,
@@ -102,7 +102,7 @@ function computeStyles(width, browserWidth) {
     byline: {
       fontFamily: headerFont,
       fontSize: 15,
-      marginLeft: 152,
+      marginLeft: 102,
       marginTop: 5,
       marginBottom: 5,
       fontWeight: 500,

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -81,7 +81,7 @@ function computeStyles(width, browserWidth) {
     title: {
       fontFamily: titleFont,
       fontSize: fontSize,
-      marginLeft: 0,
+      marginLeft: 150,
       marginTop: 0,
       marginBottom: 5,
       fontWeight: 500,
@@ -92,7 +92,7 @@ function computeStyles(width, browserWidth) {
     n: {
       fontFamily: headerFont,
       fontSize: 14,
-      marginLeft: 2,
+      marginLeft: 152,
       marginTop: 5,
       marginBottom: 5,
       fontWeight: 500,
@@ -102,7 +102,7 @@ function computeStyles(width, browserWidth) {
     byline: {
       fontFamily: headerFont,
       fontSize: 15,
-      marginLeft: 2,
+      marginLeft: 152,
       marginTop: 5,
       marginBottom: 5,
       fontWeight: 500,

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -172,7 +172,7 @@ export const months = {
   '09': 'Sep'
 };
 
-export const normalNavBarHeight = 120;
+export const normalNavBarHeight = 110;
 export const narrativeNavBarHeight = 55;
 
 export const NODE_NOT_VISIBLE = 0;          // branch thickness 0 and excluded from map

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -172,7 +172,7 @@ export const months = {
   '09': 'Sep'
 };
 
-export const normalNavBarHeight = 50;
+export const normalNavBarHeight = 120;
 export const narrativeNavBarHeight = 55;
 
 export const NODE_NOT_VISIBLE = 0;          // branch thickness 0 and excluded from map


### PR DESCRIPTION
A few tweaks to the Nextstrain display which will allow more space for a larger back button when embedded in ViewBovis.  The position of the sidebar open/close chevron has been adjusted for both scenarios as shown below, and the page title lines have been moved to the right:

With sidebar open:
![image](https://user-images.githubusercontent.com/9665142/236161968-55519012-fd22-44ad-8d5b-f8ab13a6ade8.png)

With sidebar closed:
![image](https://user-images.githubusercontent.com/9665142/236162501-7289c853-3d6b-4be5-a386-3f1448dc6fbf.png)



