### PR TITLE
Fix display of names on Nextstrain tree

### DIFF
--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -557,7 +557,7 @@ function getTipLabelPadding(params, inViewTerminalNodes) {
 
     inViewTerminalNodes.forEach((d) => {
       if (padBy < d.n.name.length) {
-        padBy = 0.65 * d.n.name.length * fontSize;
+        padBy = 0.75 * d.n.name.length * fontSize;
       }
     });
   }


### PR DESCRIPTION
Just a small change to the Auspice code to enable the longer sample names to be displayed on the extremities of the tree.  Currently the display looks like this, with the end of the longer sample names cut off
![image](https://github.com/APHA-CSU/auspice/assets/9665142/94ee1a31-94a6-4fd8-a13f-c421a8d48a25)

After the change it looks like this:
![image](https://github.com/APHA-CSU/auspice/assets/9665142/073f9eba-de83-43e7-abad-dbbdb8633af7)


